### PR TITLE
Add a guard condition to the PS class transformer.

### DIFF
--- a/src/main/java/lumien/perfectspawn/Transformer/PSClassTransformer.java
+++ b/src/main/java/lumien/perfectspawn/Transformer/PSClassTransformer.java
@@ -38,6 +38,9 @@ public class PSClassTransformer implements IClassTransformer
 	@Override
 	public byte[] transform(String name, String transformedName, byte[] data)
 	{
+		if (data == null)
+			return null;
+
 		logger.log(Level.DEBUG, "Transforming "+name);
 		ClassNode classNode = new ClassNode();
 		ClassReader classReader = new ClassReader(data);


### PR DESCRIPTION
This prevents perfectspawn from crashing when data is null- this generally happens when a classnotfoundexception is about to trigger, but without this clause, perfectspawn will show up in the stack trace and be blamed. 
